### PR TITLE
Finish rename, prepare for automatic testing, lint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+matrix:
+  fast_finish: true
+  include:
+    - python: "3.4.2"
+      env: TOXENV=py34
+    - python: "3.5"
+      env: TOXENV=py35
+    - python: "3.6"
+      env: TOXENV=py36
+    - python: "3.6-dev"
+      env: TOXENV=py36
+cache:
+  directories:
+    - $HOME/.cache/pip
+install:
+  - pip install -r requirements_test.txt
+  - python3 setup.py develop
+language: python
+script:
+  - py.test
+  - flake8

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 openikeatradfri
+Copyright (c) 2017 opentradfri
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/opentradfri/coap_cli.py
+++ b/opentradfri/coap_cli.py
@@ -36,7 +36,7 @@ def api_factory(host, security_code):
             'timeout': 10,
             'stderr': subprocess.STDOUT,
         }
-        
+
         if data is not None:
             kwargs['input'] = json.dumps(data).encode('utf-8')
             command.append('-f')

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,1 +1,2 @@
 pytest
+flake8

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,5 +1,5 @@
-from openikeatradfri.const import ROOT_DEVICES, ATTR_NAME
-from openikeatradfri.device import Device
+from opentradfri.const import ROOT_DEVICES, ATTR_NAME
+from opentradfri.device import Device
 
 LIGHT = {
     '3': {

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,5 +1,5 @@
-from openikeatradfri.const import ROOT_DEVICES, ATTR_NAME
-from openikeatradfri.gateway import Gateway
+from opentradfri.const import ROOT_DEVICES, ATTR_NAME
+from opentradfri.gateway import Gateway
 
 
 def test_get_device(mock_api):


### PR DESCRIPTION
- The tests didn't get updated during the rename so no longer worked.
- Adds a TravisCI file to automatically run the tests + flake8
- Fix the lint issue the flake8 found.

After this PR, to enable TravisCI, [go here](https://travis-ci.org/profile)
